### PR TITLE
replacing Arduino methods with IDF's 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.5)
+
+FILE(GLOB_RECURSE app_sources "*.cpp")
+
+# Build InterruptButton as an ESP-IDF component
+if(ESP_PLATFORM)
+    idf_component_register(
+        SRCS ${app_sources}
+        INCLUDE_DIRS "."
+        #REQUIRES ${depends}
+        #PRIV_REQUIRES
+    )
+return()
+endif()
+
+project(InterruptButton VERSION 1.0.0)
+#target_compile_options(${COMPONENT_TARGET} PRIVATE -fno-rtti)

--- a/Examples/InterruptButtonExample.ino
+++ b/Examples/InterruptButtonExample.ino
@@ -36,8 +36,8 @@ void menu1Button2doubleClick(void);
 
 
 //-- BUTTON VARIABLES -----------------------------------------
-InterruptButton button1(BUTTON_1, INPUT_PULLUP, LOW);
-InterruptButton button2(BUTTON_2, INPUT_PULLUP, LOW);
+InterruptButton button1(BUTTON_1, LOW);
+InterruptButton button2(BUTTON_2, LOW);
 
 //== MAIN SETUP FUNCTION ===========================================================================
 //==================================================================================================

--- a/InterruptButton.cpp
+++ b/InterruptButton.cpp
@@ -3,7 +3,7 @@
 /* ToDo
   make the following procedures arduino independent:
     pin onChange interrupt control, ie setup fully once, then simple bit set enable/disable.
-    pin reading (digitalRead) change to IDF's MUX register acces
+    pin reading (digitalRead) change to IDF's MUX register acces              (DONE!)
     setting inputs (pinMode)
   hopefully set pin onchange interrupt toggle to a single command once set up
 
@@ -36,7 +36,7 @@ void IRAM_ATTR InterruptButton::readButton(void *arg){
 
     case ConfirmingPress:                                       // we get here each time the debounce timer expires (onchange interrupt disabled remember)
       btn->m_totalPolls++;                                                    // Count the number of total reads
-      if(digitalRead(btn->m_pin) == btn->m_pressedState) btn->m_validPolls++; // Count the number of valid 'PRESSED' reads
+      if(gpio_get_level(btn->m_pin) == btn->m_pressedState) btn->m_validPolls++; // Count the number of valid 'PRESSED' reads
       if(btn->m_totalPolls >= m_targetPolls){                                 // If we have checked the button enough times, then make a decision on key state
         if(btn->m_validPolls * 2 > btn->m_totalPolls) {                       // VALID KEYDOWN, assumed pressed if it had valid polls more than half the time
           if(!btn->m_wtgForDoubleClick){
@@ -65,7 +65,7 @@ void IRAM_ATTR InterruptButton::readButton(void *arg){
     case WaitingForRelease:  // we get here when debounce timer alarms (onchange interrupt disabled remember)
       // Evaluate polling history and make a decision; done differently because we can't afford to miss a release, we keep polling until it is released.
       btn->m_totalPolls++;
-      if(digitalRead(btn->m_pin) != btn->m_pressedState){
+      if(gpio_get_level(btn->m_pin) != btn->m_pressedState){
         btn->m_validPolls++;
         if(btn->m_totalPolls >= m_targetPolls && btn->m_validPolls * 2 > btn->m_totalPolls) { // VALID RELEASE DETECTED
           killTimer(btn->m_buttonLPandRepeatTimer);                                           // Kill the longPress and autoRepeat timer associated with holding button down
@@ -223,7 +223,7 @@ void InterruptButton::begin(void){
     }
     pinMode(m_pin, m_pinMode);                                              // Set pullups for button pin, if any
     setButtonChangeInterrupt(this, true);                                   // Enable onchange interrupt for button pin 
-    m_state = (digitalRead(m_pin) == m_pressedState) ? Pressed : Released;  // Set to current state when initialising
+    m_state = (gpio_get_level(m_pin) == m_pressedState) ? Pressed : Released;  // Set to current state when initialising
   } else {
     Serial.println("Error: Interrupt Button must be 'INPUT_PULLUP' or 'INPUT_PULLDOWN' or 'INPUT'");
   }

--- a/InterruptButton.h
+++ b/InterruptButton.h
@@ -1,8 +1,9 @@
 #ifndef InterruptButton_h
 #define InterruptButton_h
 
-#include <Arduino.h>
-#include <FunctionalInterrupt.h>  // Necessary to use std::bind to bind arguments to ISR in attachInterrupt()
+#include "driver/gpio.h"
+#include "esp_timer.h"
+#include <functional>  // Necessary to use std::bind to bind arguments to ISR in attachInterrupt()
 
 // -- Interrupt Button and Debouncer ---------------------------------------------------------------------------------------
 // -- ----------------------------------------------------------------------------------------------------------------------
@@ -24,7 +25,7 @@ class InterruptButton {
     static void longPressDelay(void *arg);                                  // Wrapper / callback to excecute a longPress event
     static void autoRepeatPressEvent(void *arg);                            // Wrapper / callback to excecute a autoRepeatPress event
     static void doubleClickTimeout(void *arg);                              // Used to separate double-clicks from regular keyPress's
-    static void setButtonChangeInterrupt(InterruptButton* btn, bool enabled, bool clearFlags = true);    // Helper function to simplify toggling the pin change interrupt
+    static void setButtonChangeInterrupt(gpio_num_t gpio, bool enabled, bool clearFlags = true);    // Helper function to simplify toggling the pin change interrupt
     static void startTimer(esp_timer_handle_t &timer, uint32_t duration_US, void (*callBack)(void* arg), InterruptButton* btn, const char *msg);
     static void killTimer(esp_timer_handle_t &timer);                       // Helper function to kill a timer
 
@@ -40,7 +41,9 @@ class InterruptButton {
     esp_timer_handle_t m_buttonLPandRepeatTimer;                            // Instance specific timer for button longPress and autoRepeat timing
     esp_timer_handle_t m_buttonDoubleClickTimer;                            // Instance specific timer for policing double-clicks
 
-    uint8_t m_pin, m_pinMode, m_pressedState;                               // Instance specific particulars about the hardware button
+    uint8_t m_pressedState;                                                 // Instance specific particulars about the hardware button
+    gpio_num_t m_pin;                                                       // Button gpio
+    gpio_mode_t m_pinMode;                                                  // GPIO mode: IDF's input/output mode
     volatile uint8_t m_keyPressMenuLevel, m_longKeyPressMenuLevel,          // Variables to store current menulevel when event occurs (the menu level ...
                      m_autoRepeatPressMenuLevel, m_doubleClickMenuLevel;    // ... may have been changed by time sync event called in main loop))
     uint16_t m_pollIntervalUS, m_longKeyPressMS, m_autoRepeatMS,            // Timing variables
@@ -74,11 +77,13 @@ class InterruptButton {
     static uint8_t getMenuLevel();                                          // Retrieves menu level
 
     // Non-static instance specific member declarations ----------------------------------
-    InterruptButton(uint8_t pin, uint8_t pinMode, uint8_t pressedState,     // Class Constructor
+    InterruptButton(uint8_t pin, uint8_t pressedState, gpio_mode_t pinMode = GPIO_MODE_INPUT,      // Class Constructor
                     uint16_t longPressMS = 750, uint16_t autoRepeatMS = 250,
                     uint16_t doubleClickMS = 200, uint32_t debounceUS = 8000);
     ~InterruptButton();                                                     // Class Destructor
     void begin();                                                           // Instance initialiser    
+    gpio_num_t getGPIO() const { return m_pin;}                                    // return monitored gpio number
+
     void enableEvents(),            disableEvents();                        // Enable / Disable sync and async events together
     bool syncEventsEnabled = true,  asyncEventsEnabled = true;
     bool longPressEnabled = false,  autoRepeatEnabled = false,  doubleClickEnabled = false;
@@ -95,7 +100,7 @@ class InterruptButton {
 // References to external functions for Asychronous (instantaneous) events
 // These should be defined with IRAM_ATTR and be as short as possible.
 // Each one is a pointer to a dynamic array of function pointers
-    func_ptr** eventActions;
+    func_ptr** eventActions = nullptr;
     void bind(  uint8_t event, func_ptr action);                              // Used to bind/unbind action to an event at current m_menuLevel
     void unbind(uint8_t event);
     void bind(  uint8_t event, uint8_t menuLevel, func_ptr action);           // Used to bind/unbind action to an event at specified menu level

--- a/InterruptButton.h
+++ b/InterruptButton.h
@@ -5,6 +5,7 @@
 #include "esp_timer.h"
 #include <functional>  // Necessary to use std::bind to bind arguments to ISR in attachInterrupt()
 
+
 // -- Interrupt Button and Debouncer ---------------------------------------------------------------------------------------
 // -- ----------------------------------------------------------------------------------------------------------------------
 class InterruptButton {
@@ -25,7 +26,7 @@ class InterruptButton {
     static void longPressDelay(void *arg);                                  // Wrapper / callback to excecute a longPress event
     static void autoRepeatPressEvent(void *arg);                            // Wrapper / callback to excecute a autoRepeatPress event
     static void doubleClickTimeout(void *arg);                              // Used to separate double-clicks from regular keyPress's
-    static void setButtonChangeInterrupt(gpio_num_t gpio, bool enabled, bool clearFlags = true);    // Helper function to simplify toggling the pin change interrupt
+    static void setButtonChangeInterrupt(gpio_num_t gpio, bool enabled);    // Helper function to simplify toggling the pin change interrupt
     static void startTimer(esp_timer_handle_t &timer, uint32_t duration_US, void (*callBack)(void* arg), InterruptButton* btn, const char *msg);
     static void killTimer(esp_timer_handle_t &timer);                       // Helper function to kill a timer
 


### PR DESCRIPTION
Hi @rwmingis 
I've made the changes required to build the lib without any dependency to Arduino.h. Also it could be build solely as an IDF component via provided CMake file.

Pls, check commits one by one, I've tried to make it as granular as possible. Had to change constructor a little bit. 
You may wanna merge this into some separate branch and make you corrections there on top of my changes.
That way it would be easier for me to rebase further changes if any.
Having this as a milestone next thing I'll try to do some more drastic changes and introduce RTOS queue or event to ISR handling. This way I suppose it would be possible to fix the issue with dynamic button objects.

Let me know if you have any questions or concerns.
Cheers!