### PR TITLE
Allow button to be reconfigured at runtime (close #18 and fix #24)

### DIFF
--- a/InterruptButton.h
+++ b/InterruptButton.h
@@ -8,6 +8,7 @@
 
 #include "driver/gpio.h"
 #include "esp_timer.h"
+#include "esp32-hal-gpio.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
@@ -121,6 +122,15 @@ class InterruptButton {
                                                                       // Must be set before initialsing/binding first button or calling setMode().
 
     // Non-static instance specific member declarations ----------------------------------
+
+    // when using this constructor and not setting a pin, you must initialize a pin later with setPin()
+    InterruptButton(uint8_t pressedState = LOW,
+                    gpio_mode_t pinMode = GPIO_MODE_INPUT,
+                    uint16_t longKeyPressMS = 750,
+                    uint16_t autoRepeatMS =   250,
+                    uint16_t doubleClickMS =  333,
+                    uint32_t debounceUS =     8000);
+ 
     InterruptButton(uint8_t pin,                                      // Class Constructor, pin to monitor
                     uint8_t pressedState,                             // State of the pin when pressed (HIGH or LOW)
                     gpio_mode_t pinMode = GPIO_MODE_INPUT,
@@ -129,6 +139,14 @@ class InterruptButton {
                     uint16_t doubleClickMS =  333,
                     uint32_t debounceUS =     8000);
     ~InterruptButton();                                               // Class Destructor
+
+    void setPin(uint8_t pin);
+    void setPressedState(uint8_t pressedState) { m_pressedState = pressedState; }
+    void setPinMode(gpio_mode_t pinMode) { m_pinMode = pinMode; }
+    void setLongKeyPressMS(uint16_t longKeyPressMS) { m_longKeyPressMS = longKeyPressMS; }
+    void setAutoRepeatMS(uint16_t autoRepeatMS) { m_autoRepeatMS = autoRepeatMS; }
+    void setDoubleClickMS(uint16_t doubleClickMS) { m_doubleClickMS = doubleClickMS; }
+    void setDebounceUS(uint32_t debounceUS) { m_pollIntervalUS = (debounceUS / TARGET_POLLS > 65535) ? 65535 : debounceUS / TARGET_POLLS; }
 
     void            enableEvent(events event);                        // Enable the event passed as argument (updates bitmask)
     void            disableEvent(events event);                       // Disable the event passed as argument (updates bitmask)


### PR DESCRIPTION
- Close #18 
- Fix #24

**Usage:**

declare the button in your class:

```cpp
  private:
    InterruptButton _button;
  };
```

In the begin method, initialise the button as usual. But note the use of `setPin`. Other getters are available:

- `setPin`
- `setPressedState`
- `setPinMode`
- `setLongKeyPressMS`
- `setAutoRepeatMS`
- `setDoubleClickMS`
- `setDebounceUS`

```cpp
  InterruptButton::setMode(Mode_Synchronous);

  _button.setPin(pin);
  _button.setLongPressInterval(8000);
  _button.bind(events::Event_KeyPress, [this]()
               { _callback(ButtonConfig.getPressAction()); });
  _button.bind(events::Event_LongKeyPress, [this]()
               { _callback(ButtonConfig.getLongPressAction()); });

```

if you want to "release" the button:

```cpp
  _button.unbind(events::Event_KeyPress);
  _button.unbind(events::Event_LongKeyPress);
  _button.setPin(GPIO_NUM_NC);
```

if you want to just change the pin, the code will automatically deregister the existing interrupt handler and create a new one:

```cpp
  _button.setPin(a_new_number);
```

The previous behaviour is kept, which is to initialise things within the first `bind()` call.

All that has been tested - I am using that in my project currently.